### PR TITLE
Separate routing-history aside of main index file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ styles/
 bak/
 storybook-static/
 build/
+routing-history.js

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Example - react to new route and clean data when leaving it
 
 ```js
 import { runRouteDependencies } from '@ackee/chris';
-import { routingHistory } from '@ackee/chris';
+import routingHistory from '@ackee/chris/routing-history';
 
 const { activeLocationSelectorFactory, previousLocationSelectorFactory } = routingHistory;
 
@@ -115,7 +115,7 @@ TBD
 There is a routing history module for handling history in redux & react-router apps called [routingHistory](./src/modules/routing-history/README.md)
 
 ```js
-import { routingHistory } from '@ackee/chris';
+import routingHistory from '@ackee/chris/routing-history';
 ```
 
 --- 

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,30 +841,6 @@
                 "regexpu-core": "^4.1.3"
             }
         },
-        "@babel/polyfill": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-            "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.6.5",
-                "regenerator-runtime": "^0.13.2"
-            },
-            "dependencies": {
-                "core-js": {
-                    "version": "2.6.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-                    "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-                    "dev": true
-                },
-                "regenerator-runtime": {
-                    "version": "0.13.2",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-                    "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-                    "dev": true
-                }
-            }
-        },
         "@babel/preset-env": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.2.3.tgz",
@@ -2560,41 +2536,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "auto-changelog": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.13.0.tgz",
-            "integrity": "sha512-djreNOUH6i09Lkm/A3oDApJjSrphUb8dxnyCan8CVEN1uHrD02NlraZic9VdPu37ZYcf1lqYNLjuwT5CFZxtPw==",
-            "dev": true,
-            "requires": {
-                "@babel/polyfill": "^7.4.3",
-                "commander": "^2.20.0",
-                "handlebars": "^4.0.12",
-                "lodash.uniqby": "^4.7.0",
-                "node-fetch": "^2.3.0",
-                "parse-github-url": "^1.0.2",
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-                    "dev": true
-                },
-                "node-fetch": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.4.1.tgz",
-                    "integrity": "sha512-P9UbpFK87NyqBZzUuDBDz4f6Yiys8xm8j7ACDbi6usvFm6KItklQUKjeoqTrYS/S1k6I8oaOC2YLLDr/gg26Mw==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-                    "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
-                    "dev": true
-                }
-            }
-        },
         "autoprefixer": {
             "version": "9.4.4",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
@@ -4172,11 +4113,8 @@
             "from": "github:AckeeCZ/changelog-it",
             "dev": true,
             "requires": {
-                "auto-changelog": "^1.11.0",
-                "commander": "^2.19.0",
                 "keep-a-changelog": "^0.7.0",
-                "lodash": "^4.17.11",
-                "prompt": "^1.0.0"
+                "lodash": "^4.17.11"
             }
         },
         "character-entities": {
@@ -4598,7 +4536,8 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
             "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -5122,12 +5061,6 @@
             "requires": {
                 "array-find-index": "^1.0.1"
             }
-        },
-        "cycle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-            "dev": true
         },
         "cyclist": {
             "version": "0.2.2",
@@ -6591,12 +6524,6 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
         },
-        "eyes": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-            "dev": true
-        },
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -6982,7 +6909,8 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -7006,13 +6934,15 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -7029,19 +6959,22 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -7172,7 +7105,8 @@
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -7186,6 +7120,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -7202,6 +7137,7 @@
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -7210,13 +7146,15 @@
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
                     "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -7237,6 +7175,7 @@
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -7325,7 +7264,8 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -7339,6 +7279,7 @@
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -7434,7 +7375,8 @@
                     "version": "5.1.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                     "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -7476,6 +7418,7 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -7497,6 +7440,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -7545,13 +7489,15 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
                     "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -8237,12 +8183,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-            "dev": true
-        },
-        "i": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
             "dev": true
         },
         "iconv-lite": {
@@ -10481,12 +10421,6 @@
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
             "dev": true
         },
-        "lodash.uniqby": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-            "dev": true
-        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -11018,12 +10952,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
-        "ncp": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-            "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
             "dev": true
         },
         "nearley": {
@@ -12148,12 +12076,6 @@
                 "is-hexadecimal": "^1.0.0"
             }
         },
-        "parse-github-url": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-            "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-            "dev": true
-        },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -12379,12 +12301,6 @@
                     "dev": true
                 }
             }
-        },
-        "pkginfo": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-            "dev": true
         },
         "pluralize": {
             "version": "7.0.0",
@@ -12724,20 +12640,6 @@
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.9.0",
                 "function-bind": "^1.1.1"
-            }
-        },
-        "prompt": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
-            "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
-            "dev": true,
-            "requires": {
-                "colors": "^1.1.2",
-                "pkginfo": "0.x.x",
-                "read": "1.0.x",
-                "revalidator": "0.1.x",
-                "utile": "0.3.x",
-                "winston": "2.1.x"
             }
         },
         "prompts": {
@@ -13410,15 +13312,6 @@
                 "velocity-react": "^1.4.1"
             }
         },
-        "read": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-            "dev": true,
-            "requires": {
-                "mute-stream": "~0.0.4"
-            }
-        },
         "read-all-stream": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -13971,12 +13864,6 @@
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
-        },
-        "revalidator": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-            "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
             "dev": true
         },
         "rimraf": {
@@ -14853,12 +14740,6 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-            "dev": true
-        },
-        "stack-trace": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "dev": true
         },
         "stack-utils": {
@@ -16276,34 +16157,6 @@
             "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
             "dev": true
         },
-        "utile": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
-            "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
-            "dev": true,
-            "requires": {
-                "async": "~0.9.0",
-                "deep-equal": "~0.2.1",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "1.0.x",
-                "rimraf": "2.x.x"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                },
-                "deep-equal": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-                    "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-                    "dev": true
-                }
-            }
-        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -16733,41 +16586,6 @@
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
-                }
-            }
-        },
-        "winston": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-            "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
-            "dev": true,
-            "requires": {
-                "async": "~1.0.0",
-                "colors": "1.0.x",
-                "cycle": "1.0.x",
-                "eyes": "0.1.x",
-                "isstream": "0.1.x",
-                "pkginfo": "0.3.x",
-                "stack-trace": "0.0.x"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-                    "dev": true
-                },
-                "colors": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                    "dev": true
-                },
-                "pkginfo": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                    "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "module": "es/index.js",
     "scripts": {
         "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --ignore \"**/*.story.tsx,**/*.d.ts\" --source-maps inline",
+        "build:indexFiles": "babel ./*.ts --out-dir . --extensions \".ts\"  --source-maps inline",
         "build:types": "tsc --project tsconfig.types.json --emitDeclarationOnly",
-        "build": "npm run clean && npm run type-check && npm run build:js && npm run build:types",
+        "build": "npm run clean && npm run type-check && npm run build:js && npm run build:indexFiles && npm run build:types",
         "storybook": "rm -rf build && start-storybook -p 6006",
         "build-storybook": "cross-env BABEL_ENV=development build-storybook -o build",
         "lint": "tslint \"src/**/*.{ts,tsx}\"",

--- a/routing-history.ts
+++ b/routing-history.ts
@@ -1,0 +1,3 @@
+import * as routingHistory from './src/modules/routing-history';
+
+export default routingHistory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-import * as routingHistory from './modules/routing-history';
-
-export { routingHistory };
-
 export * from './HOC';
 export * from './services/selectors';
 export * from './services/sagas';

--- a/src/modules/routing-history/README.md
+++ b/src/modules/routing-history/README.md
@@ -15,7 +15,7 @@ To make the module working, you have to inject its reducer and saga into your ap
 ### Reducer
 
 ```javascript
-import { routingHistory } from '@ackee/chris';
+import routingHistory from '@ackee/chris/routing-history';
 ...
 
 const { reducer: history } = routingHistory;
@@ -32,7 +32,7 @@ export default reducer;
 ### Saga
 
 ```javascript
-import { routingHistory } from  '@ackee/chris';
+import routingHistory from  '@ackee/chris/routing-history';
 ...
 
 const { saga: history } = routingHistory;


### PR DESCRIPTION
I put a `routing-history` submodule as a standalone part of package, importable by its own way. The reason for it is, to avoid importing the module in a case I need only few (or one) utils like `fetchDependencies`. It happened at Mech****** project, separating `@ackee/chris` into vendor bundle caused failing build with error `Can't resolve 'connected-react-router' in 'SOME_PATH_TO_PROJECT/node_modules/@ackee/chris/lib/modules/routing-history'`.