### PR TITLE
Pass to onLoad and to onUnload methods meta object with mounting flag

### DIFF
--- a/src/HOC/fetchDependencies.ts
+++ b/src/HOC/fetchDependencies.ts
@@ -38,6 +38,7 @@ export interface OptionalProps {
 
 export interface OptionalMeta {
     mounting: boolean;
+    unmounting: boolean;
 }
 
 interface Config<P> {
@@ -62,6 +63,7 @@ const fetchDependencies = <P>(config?: Partial<Config<P>>) => {
                 } else {
                     onLoad(this.props, {
                         mounting: true,
+                        unmounting: false,
                     });
                 }
             },
@@ -75,6 +77,7 @@ const fetchDependencies = <P>(config?: Partial<Config<P>>) => {
                 } else if (shouldReFetch(prevProps, this.props)) {
                     const meta = {
                         mounting: false,
+                        unmounting: false,
                     };
                     onUnload(this.props, meta);
                     onLoad(this.props, meta);
@@ -85,7 +88,8 @@ const fetchDependencies = <P>(config?: Partial<Config<P>>) => {
                     log.error.unload(onUnload);
                 } else {
                     onUnload(this.props, {
-                        mounting: true,
+                        mounting: false,
+                        unmounting: true,
                     });
                 }
             },

--- a/src/HOC/fetchDependencies.ts
+++ b/src/HOC/fetchDependencies.ts
@@ -36,9 +36,13 @@ export interface OptionalProps {
     clear?: (...args: any[]) => void;
 }
 
+export interface OptionalMeta {
+    mounting: boolean;
+}
+
 interface Config<P> {
-    onLoad: (props: P & OptionalProps) => void;
-    onUnload: (props: P & OptionalProps) => void;
+    onLoad: (props: P & OptionalProps, meta?: OptionalMeta) => void;
+    onUnload: (props: P & OptionalProps, meta?: OptionalMeta) => void;
     shouldReFetch: (prevProps: P, props: P) => boolean;
 }
 
@@ -56,7 +60,9 @@ const fetchDependencies = <P>(config?: Partial<Config<P>>) => {
                 if (typeof onLoad !== 'function') {
                     log.error.load(onLoad);
                 } else {
-                    onLoad(this.props);
+                    onLoad(this.props, {
+                        mounting: true,
+                    });
                 }
             },
             componentDidUpdate(prevProps: P) {
@@ -67,15 +73,20 @@ const fetchDependencies = <P>(config?: Partial<Config<P>>) => {
                 } else if (typeof onUnload !== 'function') {
                     log.error.unload(onUnload);
                 } else if (shouldReFetch(prevProps, this.props)) {
-                    onUnload(this.props);
-                    onLoad(this.props);
+                    const meta = {
+                        mounting: false,
+                    };
+                    onUnload(this.props, meta);
+                    onLoad(this.props, meta);
                 }
             },
             componentWillUnmount() {
                 if (typeof onUnload !== 'function') {
                     log.error.unload(onUnload);
                 } else {
-                    onUnload(this.props);
+                    onUnload(this.props, {
+                        mounting: true,
+                    });
                 }
             },
         }),

--- a/src/HOC/routeDependencies.ts
+++ b/src/HOC/routeDependencies.ts
@@ -1,6 +1,6 @@
 import { compose } from 'redux';
 import { withRouter, RouteComponentProps } from 'react-router';
-import fetchDependencies, { OptionalProps } from './fetchDependencies';
+import fetchDependencies, { OptionalProps, OptionalMeta } from './fetchDependencies';
 
 const shouldReRoue = (oldProps: RouteComponentProps, newProps: RouteComponentProps) =>
     oldProps.location.pathname !== newProps.location.pathname ||
@@ -8,8 +8,8 @@ const shouldReRoue = (oldProps: RouteComponentProps, newProps: RouteComponentPro
     oldProps.location.hash !== newProps.location.hash;
 
 interface Config<P> {
-    onRouteEnter?: (props: P) => void;
-    onRouteLeave?: (props: P) => void;
+    onRouteEnter?: (props: P, meta?: OptionalMeta) => void;
+    onRouteLeave?: (props: P, meta?: OptionalMeta) => void;
     shouldReRoute?: (prevProps: P, props: P) => boolean;
 }
 


### PR DESCRIPTION
Add following meta object to `onLoad` and `onUnload` methods:
```js
interface OptionalMeta {
    mounting: boolean;
}
```
This is useful for knowing which `onRouteEnter` method call was trigger by component mounting and which one by component updating.
E.g.:
```js
{
  onRouteEnter(props, meta) {
    if (!meta.mounting) {
         // do something only on update  
    }
  }
}
```