### PR TITLE
:pencil: Add basic documentation of routing-history selectors

### DIFF
--- a/routing-history.js
+++ b/routing-history.js
@@ -1,0 +1,14 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var routingHistory = _interopRequireWildcard(require("./lib/modules/routing-history"));
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+var _default = routingHistory;
+exports.default = _default;
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJvdXRpbmctaGlzdG9yeS50cyJdLCJuYW1lcyI6WyJyb3V0aW5nSGlzdG9yeSJdLCJtYXBwaW5ncyI6Ijs7Ozs7OztBQUFBOzs7O2VBRWVBLGMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgKiBhcyByb3V0aW5nSGlzdG9yeSBmcm9tICcuL2xpYi9tb2R1bGVzL3JvdXRpbmctaGlzdG9yeSc7XG5cbmV4cG9ydCBkZWZhdWx0IHJvdXRpbmdIaXN0b3J5O1xuIl19

--- a/src/modules/routing-history/README.md
+++ b/src/modules/routing-history/README.md
@@ -8,6 +8,12 @@ Routing history is a module for storing your routing history into redux store. I
 
 As you can see, the module is intended to be used with **React**, **Redux** and **React-router**.
 
+## Table of contents
+
+* [Reducer](#reducer)
+* [Saga](#saga)
+* [Selectors](#selectors)
+
 ## Usage
 
 To make the module working, you have to inject its reducer and saga into your application.
@@ -47,4 +53,39 @@ export default function*() {
 ```
 
 By now, the module is working. It listens on `LOCATION_CHANGE` action from **connected-react-router** and stores the info into the history reducer via the history saga. 
-If you want to access the info in the history reducer, we expose you two selectors. You can use them together with our `runRouteDependecies` helper to realize _on-route-change_ and _post-route-change_ actions.
+
+### Selectors
+If you want to access the info in the history reducer, we expose you two selectors factories to make the selectors. 
+
+For example of using factories we're going to use `history` for a reducer name as in reducer usage example.
+
+* #### `previousLocationSelectorFactory(reducerName: string): Function`
+
+    Selector returns previous route at app or `{ pathname: '' }` if it's a first route.
+
+    ```js
+    import routingHistory from '@ackee/chris/routing-history';
+
+    const previousLocationSelector = previousLocationSelectorFactory('history');
+
+    const mapStateToProps = state => ({
+        previousLocation: previousLocationSelector(state),
+    });
+    ```
+
+
+* #### `activeLocationSelectorFactory(reducerName: string): Function`
+
+    Selector returns current app route or `{ pathname: '' }` if current route not set yet.
+
+    ```js
+    import routingHistory from '@ackee/chris/routing-history';
+
+    const activeLocationSelector = activeLocationSelectorFactory('history');
+
+    const mapStateToProps = state => ({
+        activeLocation: activeLocationSelector(state),
+    });
+    ```
+
+You can use the selectors together with our `runRouteDependecies` helper to realize _on-route-change_ and _post-route-change_ actions.


### PR DESCRIPTION
Fixes #5 

Add missing basic documentation of `routing-history` selectors.